### PR TITLE
Show only commit title instead of full commit log

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,8 +116,11 @@
                         l.payload.commits.forEach(function (commit) {
                             if (commit.message.substring(0, 28) != "Merge remote-tracking branch") {
                                 if (_msg != commit.message.trim()) {
-                                    if (commit.author.name == authorName)
-                                        commits.push({url: commit.url.replace("https://api.", "https://").replace("repos/", ""), message: commit.message, created_at: l.created_at});
+                                    if (commit.author.name == authorName) {
+                                        var commitTitle = commit.message.split("\n")[0];
+
+                                        commits.push({url: commit.url.replace("https://api.", "https://").replace("repos/", ""), message: commitTitle, created_at: l.created_at});
+                                    }
                                     _msg = commit.message.trim();
                                 }
                             }


### PR DESCRIPTION
commit message가 길면 좀 지저분해지는거같더라고요.

https://taeung.github.io/oss-report/

그래서 첫줄 commit title만 출력하는건 어떨까생각해봤는데 어떠신가요 ?
